### PR TITLE
Change fromSets to filter out singleton sets. 

### DIFF
--- a/Data/Partition.hs
+++ b/Data/Partition.hs
@@ -48,9 +48,12 @@ empty = discrete
 -- with every remaining element being given its own set.
 fromSets :: (Ord a) => [Set.Set a] -> Partition a
 fromSets sets = Partition { 
-        forwardMap = Map.fromList [ (x, Set.findMin s) | s <- sets, x <- Set.toList s ],
-        backwardMap = Map.fromList [ (Set.findMin s, s) | s <- sets ]
+        forwardMap = Map.fromList [ (x, Set.findMin s) | s <- sets', x <- Set.toList s ],
+        backwardMap = Map.fromList [ (Set.findMin s, s) | s <- sets' ]
     }
+    where
+      sets' = filter (not.isSingleton) sets
+      isSingleton s = 1 == Set.size s
 
 -- | Returns a list of all nontrivial sets (sets with more than one element) in the 
 -- partition.

--- a/data-partition.cabal
+++ b/data-partition.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                data-partition
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            A pure disjoint set (union find) data structure
 -- description:         
 homepage:            https://github.com/luqui/data-partition


### PR DESCRIPTION
 Ensures that partitions are represented uniquely so that Eq does the right thing.  (Otherwise discrete and fromSets [Set.singleton x] represent the same partitioning in distinct ways.)
